### PR TITLE
Cope with multiple values for a given url query parameter

### DIFF
--- a/django_autologin/utils.py
+++ b/django_autologin/utils.py
@@ -9,10 +9,11 @@ def strip_token(url):
     bits = urlparse.urlparse(url)
     original_query = urlparse.parse_qsl(bits.query)
 
-    query = {}
-    for k, v in original_query:
-        if k != app_settings.KEY:
-            query[k] = v
+    query = [
+        (k, v)
+        for k, v in original_query
+        if k != app_settings.KEY
+    ]
 
     query = urlparse.urlencode(query)
 


### PR DESCRIPTION
Previously we threw away all but the last of them by ignoring this case.