### PR TITLE
Improve usability of public API

### DIFF
--- a/django_autologin/__init__.py
+++ b/django_autologin/__init__.py
@@ -1,3 +1,3 @@
-from .utils import get_automatic_login_token
+from .utils import get_automatic_login_token, validate_token
 
-__all__ = ("get_automatic_login_token",)
+__all__ = ("get_automatic_login_token", "validate_token")

--- a/django_autologin/__init__.py
+++ b/django_autologin/__init__.py
@@ -1,0 +1,3 @@
+from .utils import get_automatic_login_token
+
+__all__ = ("get_automatic_login_token",)

--- a/django_autologin/templatetags/django_autologin.py
+++ b/django_autologin/templatetags/django_autologin.py
@@ -1,6 +1,13 @@
 from django import template
 
+from .. import app_settings
 from ..utils import get_automatic_login_token
 
 register = template.Library()
-register.simple_tag(get_automatic_login_token, name="automatic_login_token")
+
+
+@register.simple_tag
+def automatic_login_token(user):
+    token = get_automatic_login_token(user)
+
+    return "%s=%s" % (app_settings.KEY, token)

--- a/django_autologin/templatetags/django_autologin.py
+++ b/django_autologin/templatetags/django_autologin.py
@@ -1,14 +1,6 @@
 from django import template
-from django.core.signing import TimestampSigner
 
-from .. import app_settings
-from ..utils import get_user_salt
+from ..utils import get_automatic_login_token
 
 register = template.Library()
-
-
-@register.simple_tag
-def automatic_login_token(user):
-    token = TimestampSigner(salt=get_user_salt(user),).sign(user.pk)
-
-    return "%s=%s" % (app_settings.KEY, token)
+register.simple_tag(get_automatic_login_token, name="automatic_login_token")

--- a/django_autologin/utils.py
+++ b/django_autologin/utils.py
@@ -6,19 +6,20 @@ from django.core.signing import TimestampSigner, BadSignature
 
 from . import app_settings
 
+SEPARATOR = ':'
 
 def get_automatic_login_token(user):
-    return TimestampSigner(
-        salt=get_user_salt(user),
-    ).sign(user.pk)
+    signer = TimestampSigner(salt=get_user_salt(user), sep=SEPARATOR)
+    return signer.sign(user.pk)
 
 
 def validate_token(user, token) -> bool:
+    if SEPARATOR not in token:
+        return False
+
     try:
-        TimestampSigner(salt=get_user_salt(user)).unsign(
-            token,
-            max_age=app_settings.MAX_AGE,
-        )
+        signer = TimestampSigner(salt=get_user_salt(user), sep=SEPARATOR)
+        signer.unsign(token, max_age=app_settings.MAX_AGE)
         return True
     except BadSignature:
         return False

--- a/django_autologin/utils.py
+++ b/django_autologin/utils.py
@@ -2,8 +2,17 @@ from six.moves.urllib import parse as urlparse
 
 from django.conf import settings
 from django.contrib import auth
+from django.core.signing import TimestampSigner
 
 from . import app_settings
+
+
+def get_automatic_login_token(user):
+    token = TimestampSigner(
+        salt=get_user_salt(user),
+    ).sign(user.pk)
+
+    return "%s=%s" % (app_settings.KEY, token)
 
 
 def strip_token(url):

--- a/django_autologin/utils.py
+++ b/django_autologin/utils.py
@@ -8,11 +8,9 @@ from . import app_settings
 
 
 def get_automatic_login_token(user):
-    token = TimestampSigner(
+    return TimestampSigner(
         salt=get_user_salt(user),
     ).sign(user.pk)
-
-    return "%s=%s" % (app_settings.KEY, token)
 
 
 def validate_token(user, token) -> bool:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 setup(
     name="django-autologin",
     url="https://chris-lamb.co.uk/projects/django-autologin",
-    version='0.3.0',
+    version='0.4.0',
     description="Token generator and processor to provide automatic login links for users",
     author="Chris Lamb",
     author_email="chris@chris-lamb.co.uk",


### PR DESCRIPTION
This PR is motivated by a need to validate tokens outside of the context of a middleware, although I have also exposed the token creation as it creates a nice symmetry and means we don't need to import template tags which isn't great layering.

I've pre-emptively bumped the version, but happy if you'd rather this was a different version.

While there aren't any tests here, an upgrade passes the tests on a large codebase that uses this library fairly extensively.