### PR TITLE
Ensure we've also got the same user account

### DIFF
--- a/django_autologin/utils.py
+++ b/django_autologin/utils.py
@@ -19,8 +19,8 @@ def validate_token(user, token) -> bool:
 
     try:
         signer = TimestampSigner(salt=get_user_salt(user), sep=SEPARATOR)
-        signer.unsign(token, max_age=app_settings.MAX_AGE)
-        return True
+        user_id = signer.unsign(token, max_age=app_settings.MAX_AGE)
+        return user_id == str(user.id)
     except BadSignature:
         return False
 


### PR DESCRIPTION
This was already enforced in middleware, but this API directly would incorrectly verify a correct token for a different account IF the salts happened to be the same – unlikely but possible.

Apologies for missing this edge case in the previous PR!